### PR TITLE
Fix roast preparation crash and improve control timing

### DIFF
--- a/iRoastControl Software/ControlClass.cs
+++ b/iRoastControl Software/ControlClass.cs
@@ -33,14 +33,20 @@ namespace Artisan
         {
             t.Stop();
 
+            t.Elapsed -= timer1_Tick;
             t.Elapsed += timer1_Tick;
-            t.Interval = deltaTime/1000;
+            t.Interval = deltaTime * 1000;
             t.Start();
 
         }
 
         public static void prepareRoast()
         {
+            if (ControlClass.elappsedSeconds == null)
+            {
+                ControlClass.elappsedSeconds = new Stopwatch();
+            }
+
             ControlClass.elappsedSeconds.Reset();
             State = "pre-heating";
             setPoint = 0;
@@ -254,15 +260,17 @@ namespace Artisan
             else { }
 
             double controlSignal;
-            if (pid == null || State != "running")
+            if (pid == null)
             {
-                //controlSignal= setPoint;
-                controlSignal = pid.Set(second, setPoint);
+                controlSignal = Math.Max(0, Math.Min(255, setPoint));
             }
-            else { 
-                controlSignal = pid.Update(second,measuredTemp);
-               // Console.WriteLine(controlSignal.ToString());
-
+            else if (State == "running")
+            {
+                controlSignal = pid.Update(second, measuredTemp);
+            }
+            else
+            {
+                controlSignal = pid.Set(second, setPoint);
             }
 
 

--- a/iRoastControl Software/CurveWindow.cs
+++ b/iRoastControl Software/CurveWindow.cs
@@ -28,9 +28,20 @@ namespace Artisan
         void loadRecipes()
         {
             comboBox2.Items.Clear();
+            if (!Directory.Exists("./Recipes/"))
+            {
+                return;
+            }
+
             var kproFiles = Directory.GetFiles("./Recipes/", "*.kpro").Select(o => Path.GetFileNameWithoutExtension(o.ToString())).ToArray();
+
+            if (kproFiles.Length == 0)
+            {
+                return;
+            }
+
             comboBox2.Items.AddRange(kproFiles.ToArray());
-            comboBox2.Text = (comboBox2.Items[0].ToString());
+            comboBox2.Text = comboBox2.Items[0].ToString();
 
         }
 


### PR DESCRIPTION
## Summary
- guard recipe loading when no recipe files are present to avoid startup crashes
- ensure roast preparation initializes the stopwatch and PID control safely to prevent null references during cooling
- correct the control timer setup to keep measurements updating until a new roast resets the graph

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68fe862d44448325b1e6f7eb9e8b8188